### PR TITLE
plugin: Add `cni-args` to pass data from the pod to the plugin

### DIFF
--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -29,6 +29,14 @@ import (
 // A NetConf structure represents a Multus network attachment definition configuration
 type NetConf struct {
 	types.NetConf
+
+	Args struct {
+		Cni CniArgs `json:"cni,omitempty"`
+	} `json:"args,omitempty"`
+}
+
+type CniArgs struct {
+	Name string `json:"name,omitempty"`
 }
 
 // EnvArgs structure represents inputs sent from each VMI via environment variables

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -60,8 +60,13 @@ func CmdAddResult(args *skel.CmdArgs) (types.Result, error) {
 
 	result := type100.Result{CNIVersion: cniVersion}
 
+	ifName := args.IfName
+	if name := netConf.Args.Cni.Name; name != "" {
+		ifName = name
+	}
+	dummy := netlink.NewDummy(ifName)
+
 	err = netns.Do(func(_ ns.NetNS) error {
-		dummy := netlink.NewDummy(args.IfName)
 		if lerr := netlink.CreateLink(dummy); lerr != nil {
 			return lerr
 		}


### PR DESCRIPTION
To pass an alternative name of the interface, use a custom arg from the pod annotation.

```
---
apiVersion: v1
kind: Pod
metadata:
  name: pods-simple-pod
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
      {"interface":"mydummy123","cni-args":{"name":"mydummy999"},"name":"test-cni","namespace":"default"}
    ]'
spec:
  containers:
    - command:
        - sleep
        - "300"
      image: busybox
      name: pods-simple-container

```